### PR TITLE
修复运行时中无证书

### DIFF
--- a/OneDriveUploader/amd64/linux/Dockerfile
+++ b/OneDriveUploader/amd64/linux/Dockerfile
@@ -1,5 +1,10 @@
 FROM debian:stable-slim
 
 WORKDIR /
-COPY OneDriveUploader /usr/bin
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates libssl1.1 openssl \
+        && rm -rf /var/lib/apt/lists/*
+
+COPY OneDriveUploader /usr/local/bin/
 CMD ["OneDriveUploader", "--help"]


### PR DESCRIPTION
构建 docker 镜像时安装证书及证书相关工具